### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Reviews are required by
+#
+# - @pennylane-hq/germany-core as main usage of this gem is for this team
+
+* @pennylane-hq/germany-core


### PR DESCRIPTION
Add the CODEOWNERS file to automatically add the `germany-core` team as reviewers to PR.