### PR TITLE
Migrate to ERiC 44 multithreading (MT) API

### DIFF
--- a/lib/liberic.rb
+++ b/lib/liberic.rb
@@ -11,9 +11,15 @@ require 'liberic/process'
 require 'liberic/config'
 
 module Liberic
-  SDK::API::initialisiere(nil, nil)
-
-  check_eric_version!
+  class << self
+    def instance
+      return @instance if @instance
+      @instance = SDK::API.mt_instanz_erzeugen(nil, '/tmp/eric-logs')
+      raise InitializationError.new('EricMtInstanzErzeugen failed') if @instance.null?
+      check_eric_version!
+      @instance
+    end
+  end
 
   def config
     @config ||= Config.new

--- a/lib/liberic.rb
+++ b/lib/liberic.rb
@@ -14,7 +14,7 @@ module Liberic
   class << self
     def instance
       return @instance if @instance
-      @instance = SDK::API.mt_instanz_erzeugen(nil, '/tmp/eric-logs')
+      @instance = SDK::API.mt_instanz_erzeugen(ERIC_LIB_FOLDER, '/tmp/eric-logs')
       raise InitializationError.new('EricMtInstanzErzeugen failed') if @instance.null?
       check_eric_version!
       @instance

--- a/lib/liberic.rb
+++ b/lib/liberic.rb
@@ -14,7 +14,7 @@ module Liberic
   class << self
     def instance
       return @instance if @instance
-      @instance = SDK::API.mt_instanz_erzeugen(ERIC_LIB_FOLDER, '/tmp/eric-logs')
+      @instance = SDK::API.mt_instanz_erzeugen(ERIC_LIB_FOLDER, nil)
       raise InitializationError.new('EricMtInstanzErzeugen failed') if @instance.null?
       check_eric_version!
       @instance

--- a/lib/liberic/boot.rb
+++ b/lib/liberic/boot.rb
@@ -25,13 +25,12 @@ module Liberic
   def check_eric_version!
     version_response = Response::Version.new(
       Helpers::Invocation.with_result_buffer do |handle|
-        SDK::API::version(handle)
+        SDK::API.mt_version(Liberic.instance, handle)
       end
     )
 
     eric_version = version_response.for_library('libericapi')
     if !SDK::Configuration::LIBERICAPI_VERSION.include?(eric_version)
-      #raise InitializationError.new("ERiC #{SDK::Configuration::LIBERICAPI_VERSION.join(', ')} required, but #{eric_version} found.")
       warn "ERiC #{SDK::Configuration::LIBERICAPI_VERSION.join(', ')} required, but #{eric_version} found."
     end
   end

--- a/lib/liberic/boot.rb
+++ b/lib/liberic/boot.rb
@@ -31,6 +31,7 @@ module Liberic
 
     eric_version = version_response.for_library('libericapi')
     if !SDK::Configuration::LIBERICAPI_VERSION.include?(eric_version)
+      #raise InitializationError.new("ERiC #{SDK::Configuration::LIBERICAPI_VERSION.join(', ')} required, but #{eric_version} found.")
       warn "ERiC #{SDK::Configuration::LIBERICAPI_VERSION.join(', ')} required, but #{eric_version} found."
     end
   end

--- a/lib/liberic/certificate.rb
+++ b/lib/liberic/certificate.rb
@@ -1,18 +1,14 @@
 module Liberic
-  # +Certificate+ encapsulates functionality regarding certificates (for signing).
-  # An instance of Certificate is passed on to +EricBearbeiteVorgang()+ where necessary.
   class Certificate
     attr_reader :features, :handle
 
-    # +cert_file+ path to a pfx file (Portal-Zertifikat)
-    # +pin+ the pin for the certificate (if applicable, string)
     def initialize(cert_file, pin)
       @pin = pin
       ch = FFI::MemoryPointer.new(:uint32, 1)
       cert_feature_flag_pointer = FFI::MemoryPointer.new(:uint32, 1)
 
       Liberic::Helpers::Invocation.raise_on_error(
-        Liberic::SDK::API.get_handle_to_certificate(ch, cert_feature_flag_pointer, cert_file)
+        Liberic::SDK::API.mt_get_handle_to_certificate(Liberic.instance, ch, cert_feature_flag_pointer, cert_file)
       )
 
       @handle = ch.get_uint32(0)
@@ -30,16 +26,12 @@ module Liberic
       )
     end
 
-    # Returns the result of +EricHoleZertifikatEigenschaften()+
-    # This will be XML describing fields and properties associated with the certificate.
     def properties
       Helpers::Invocation.with_result_buffer do |buffer_handle|
-        SDK::API.hole_zertifikat_eigenschaften(@handle, @pin, buffer_handle)
+        SDK::API.mt_hole_zertifikat_eigenschaften(Liberic.instance, @handle, @pin, buffer_handle)
       end
     end
 
-    # Returns a +SDK::Types::VerschluesselungsParameter+ data structure that can be passed on to
-    # Process.execute
     def encryption_params
       params = SDK::Types::VerschluesselungsParameter.new
 
@@ -51,7 +43,7 @@ module Liberic
     end
 
     def release_handle!
-      SDK::API.close_handle_to_certificate(@handle)
+      SDK::API.mt_close_handle_to_certificate(Liberic.instance, @handle)
     end
   end
 

--- a/lib/liberic/certificate.rb
+++ b/lib/liberic/certificate.rb
@@ -1,7 +1,11 @@
 module Liberic
+  # +Certificate+ encapsulates functionality regarding certificates (for signing).
+  # An instance of Certificate is passed on to +EricBearbeiteVorgang()+ where necessary.
   class Certificate
     attr_reader :features, :handle
 
+    # +cert_file+ path to a pfx file (Portal-Zertifikat)
+    # +pin+ the pin for the certificate (if applicable, string)
     def initialize(cert_file, pin)
       @pin = pin
       ch = FFI::MemoryPointer.new(:uint32, 1)
@@ -26,12 +30,16 @@ module Liberic
       )
     end
 
+    # Returns the result of +EricHoleZertifikatEigenschaften()+
+    # This will be XML describing fields and properties associated with the certificate.
     def properties
       Helpers::Invocation.with_result_buffer do |buffer_handle|
         SDK::API.mt_hole_zertifikat_eigenschaften(Liberic.instance, @handle, @pin, buffer_handle)
       end
     end
 
+    # Returns a +SDK::Types::VerschluesselungsParameter+ data structure that can be passed on to
+    # Process.execute
     def encryption_params
       params = SDK::Types::VerschluesselungsParameter.new
 

--- a/lib/liberic/config.rb
+++ b/lib/liberic/config.rb
@@ -95,14 +95,15 @@ module Liberic
     def [](key)
       convert_to_ruby(
         Helpers::Invocation.with_result_buffer do |handle|
-          SDK::API.einstellung_lesen(key, handle)
+          SDK::API.mt_einstellung_lesen(Liberic.instance, key, handle)
         end
       )
     end
 
     def []=(key, value)
       Helpers::Invocation.raise_on_error(
-        SDK::API.einstellung_setzen(
+        SDK::API.mt_einstellung_setzen(
+          Liberic.instance,
           key,
           convert_to_eric(value)
         )
@@ -113,7 +114,8 @@ module Liberic
 
     def install_logger
       Helpers::Invocation.raise_on_error(
-        SDK::API.registriere_log_callback(
+        SDK::API.mt_registriere_log_callback(
+          Liberic.instance,
           SDK::API.generate_log_callback do |category, level, message|
             if @logger.respond_to?(:add)
               @logger.add(SDK::Types::LOGGER_SEVERITY[level], message, category)
@@ -145,12 +147,12 @@ module Liberic
 
     def get(key)
       Helpers::Invocation.with_result_buffer(true) do |handle|
-        SDK::API.einstellung_lesen(key, handle)
+        SDK::API.mt_einstellung_lesen(Liberic.instance, key, handle)
       end
     end
 
     def set(key, value)
-      Helpers::Invocation.raise_on_error(SDK::API.einstellung_setzen(key, value))
+      Helpers::Invocation.raise_on_error(SDK::API.mt_einstellung_setzen(Liberic.instance, key, value))
       true
     end
   end

--- a/lib/liberic/helpers/invocation.rb
+++ b/lib/liberic/helpers/invocation.rb
@@ -12,25 +12,25 @@ module Liberic
       end
 
       def with_result_buffer(raise_on_error = true, &block)
-        handle = SDK::API.rueckgabepuffer_erzeugen
+        handle = SDK::API.mt_rueckgabepuffer_erzeugen(Liberic.instance)
         if raise_on_error
           raise_on_error(yield(handle))
         else
           yield(handle)
         end
-        result = Liberic::SDK::API.rueckgabepuffer_inhalt(handle)
-        SDK::API.rueckgabepuffer_freigeben(handle)
+        result = SDK::API.mt_rueckgabepuffer_inhalt(Liberic.instance, handle)
+        SDK::API.mt_rueckgabepuffer_freigeben(Liberic.instance, handle)
         result
       end
 
       def with_local_and_server_result_buffers(&block)
-        local_handle = SDK::API.rueckgabepuffer_erzeugen
-        server_handle = SDK::API.rueckgabepuffer_erzeugen
+        local_handle = SDK::API.mt_rueckgabepuffer_erzeugen(Liberic.instance)
+        server_handle = SDK::API.mt_rueckgabepuffer_erzeugen(Liberic.instance)
 
         error_code = yield(local_handle, server_handle)
 
-        local_result = Liberic::SDK::API.rueckgabepuffer_inhalt(local_handle)
-        server_result = Liberic::SDK::API.rueckgabepuffer_inhalt(server_handle)
+        local_result = SDK::API.mt_rueckgabepuffer_inhalt(Liberic.instance, local_handle)
+        server_result = SDK::API.mt_rueckgabepuffer_inhalt(Liberic.instance, server_handle)
 
         return {
           error_code: error_code,

--- a/lib/liberic/process.rb
+++ b/lib/liberic/process.rb
@@ -20,7 +20,7 @@ module Liberic
 
     def check
       Helpers::Invocation.with_result_buffer do |handle|
-        SDK::API.check_xml(@xml, @type, handle)
+        SDK::API.mt_check_xml(Liberic.instance, @xml, @type, handle)
       end
     end
 
@@ -62,7 +62,7 @@ module Liberic
       print_params = create_print_params(options)
 
       result = Helpers::Invocation.with_local_and_server_result_buffers do |local_buffer, server_buffer|
-        SDK::API.bearbeite_vorgang(@xml, @type,
+        SDK::API.mt_bearbeite_vorgang(Liberic.instance, @xml, @type,
           eric_action,
           (action == :submit ? nil : print_params),
           options[:encryption],

--- a/lib/liberic/process.rb
+++ b/lib/liberic/process.rb
@@ -58,15 +58,16 @@ module Liberic
     def execute(options = {})
       action = options[:action] ||= :validate
       eric_action = ACTIONS[action] || (raise ExecutionError.new("Invalid action: #{action}. Valid actions are #{ACTIONS.keys.join(', ')}"))
+      flags = Types::BearbeitungFlag[eric_action]
       is_printing = %w[submit print_and_submit print_and_submit_auth].include?(action.to_s)
       print_params = create_print_params(options)
 
       result = Helpers::Invocation.with_local_and_server_result_buffers do |local_buffer, server_buffer|
         SDK::API.mt_bearbeite_vorgang(Liberic.instance, @xml, @type,
-          eric_action,
+          flags,
           (action == :submit ? nil : print_params),
           options[:encryption],
-          (is_printing ? FFI::MemoryPointer.new(:uint32, 1) : nil), # transferHandle
+          (is_printing ? FFI::MemoryPointer.new(:uint32, 1) : nil),
           local_buffer,
           server_buffer)
       end

--- a/lib/liberic/process.rb
+++ b/lib/liberic/process.rb
@@ -58,13 +58,11 @@ module Liberic
     def execute(options = {})
       action = options[:action] ||= :validate
       eric_action = ACTIONS[action] || (raise ExecutionError.new("Invalid action: #{action}. Valid actions are #{ACTIONS.keys.join(', ')}"))
-      flags = SDK::Types::BearbeitungFlag[eric_action]
-      is_printing = %w[submit print_and_submit print_and_submit_auth].include?(action.to_s)
       print_params = create_print_params(options)
 
       result = Helpers::Invocation.with_local_and_server_result_buffers do |local_buffer, server_buffer|
         SDK::API.mt_bearbeite_vorgang(Liberic.instance, @xml, @type,
-          flags,
+          eric_action,
           (action == :submit ? nil : print_params),
           options[:encryption],
           local_buffer,

--- a/lib/liberic/process.rb
+++ b/lib/liberic/process.rb
@@ -67,7 +67,6 @@ module Liberic
           flags,
           (action == :submit ? nil : print_params),
           options[:encryption],
-          (is_printing ? FFI::MemoryPointer.new(:uint32, 1) : nil),
           local_buffer,
           server_buffer)
       end

--- a/lib/liberic/process.rb
+++ b/lib/liberic/process.rb
@@ -58,7 +58,7 @@ module Liberic
     def execute(options = {})
       action = options[:action] ||= :validate
       eric_action = ACTIONS[action] || (raise ExecutionError.new("Invalid action: #{action}. Valid actions are #{ACTIONS.keys.join(', ')}"))
-      flags = Types::BearbeitungFlag[eric_action]
+      flags = SDK::Types::BearbeitungFlag[eric_action]
       is_printing = %w[submit print_and_submit print_and_submit_auth].include?(action.to_s)
       print_params = create_print_params(options)
 

--- a/lib/liberic/sdk/api.rb
+++ b/lib/liberic/sdk/api.rb
@@ -247,6 +247,60 @@ module Liberic
       #     EricRueckgabepufferHandle handle);
       attach_eric_function :rueckgabepuffer_laenge, [:pointer], :uint
 
+      # --- Multithreading API ---
+
+      # ERICAPI_IMPORT EricInstanzHandle STDCALL EricMtInstanzErzeugen(
+      #     const char *pluginPfad, const char *logPfad);
+      attach_function :mt_instanz_erzeugen, :EricMtInstanzErzeugen, [:string, :string], :pointer
+
+      # ERICAPI_IMPORT int STDCALL EricMtInstanzFreigeben(EricInstanzHandle instanz);
+      attach_function :mt_instanz_freigeben, :EricMtInstanzFreigeben, [:pointer], :int
+
+      # ERICAPI_IMPORT EricRueckgabepufferHandle STDCALL EricMtRueckgabepufferErzeugen(
+      #     EricInstanzHandle instanz);
+      attach_function :mt_rueckgabepuffer_erzeugen, :EricMtRueckgabepufferErzeugen, [:pointer], :pointer
+
+      # ERICAPI_IMPORT int STDCALL EricMtRueckgabepufferFreigeben(
+      #     EricInstanzHandle instanz, EricRueckgabepufferHandle handle);
+      attach_function :mt_rueckgabepuffer_freigeben, :EricMtRueckgabepufferFreigeben, [:pointer, :pointer], :int
+
+      # ERICAPI_IMPORT const char* STDCALL EricMtRueckgabepufferInhalt(
+      #     EricInstanzHandle instanz, EricRueckgabepufferHandle handle);
+      attach_function :mt_rueckgabepuffer_inhalt, :EricMtRueckgabepufferInhalt, [:pointer, :pointer], :string
+
+      # ERICAPI_IMPORT int STDCALL EricMtBearbeiteVorgang(
+      #     EricInstanzHandle instanz, const char* datenpuffer, const char* datenartVersion,
+      #     uint32_t bearbeitungsFlags, const eric_druck_parameter_t* druckParameter,
+      #     const eric_verschluesselungs_parameter_t* cryptoParameter,
+      #     EricTransferHandle* transferHandle,
+      #     EricRueckgabepufferHandle rueckgabeXmlPuffer,
+      #     EricRueckgabepufferHandle serverantwortXmlPuffer);
+      attach_function :mt_bearbeite_vorgang, :EricMtBearbeiteVorgang, [:pointer, :string, :string,
+          Types::BearbeitungFlag, :pointer, :pointer, :pointer, :pointer, :pointer], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtCheckXML(
+      #     EricInstanzHandle instanz, const char* xml, const char* datenartVersion,
+      #     EricRueckgabepufferHandle fehlertextPuffer);
+      attach_function :mt_check_xml, :EricMtCheckXML, [:pointer, :string, :string, :pointer], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtVersion(
+      #     EricInstanzHandle instanz, EricRueckgabepufferHandle rueckgabeXmlPuffer);
+      attach_function :mt_version, :EricMtVersion, [:pointer, :pointer], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtGetHandleToCertificate(
+      #     EricInstanzHandle instanz, EricZertifikatHandle* hToken,
+      #     uint32_t* iInfoPinSupport, const byteChar* pathToKeystore);
+      attach_function :mt_get_handle_to_certificate, :EricMtGetHandleToCertificate, [:pointer, :pointer, :pointer, :string], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtCloseHandleToCertificate(
+      #     EricInstanzHandle instanz, EricZertifikatHandle hToken);
+      attach_function :mt_close_handle_to_certificate, :EricMtCloseHandleToCertificate, [:pointer, :uint], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtHoleZertifikatEigenschaften(
+      #     EricInstanzHandle instanz, EricZertifikatHandle hToken,
+      #     const byteChar* pin, EricRueckgabepufferHandle rueckgabeXmlPuffer);
+      attach_function :mt_hole_zertifikat_eigenschaften, :EricMtHoleZertifikatEigenschaften, [:pointer, :uint, :string, :pointer], :int
+
       # ERICAPI_IMPORT int STDCALL EricSystemCheck(
       #     void);
       attach_eric_function :system_check, [], :int

--- a/lib/liberic/sdk/api.rb
+++ b/lib/liberic/sdk/api.rb
@@ -276,7 +276,7 @@ module Liberic
       #     EricRueckgabepufferHandle rueckgabeXmlPuffer,
       #     EricRueckgabepufferHandle serverantwortXmlPuffer);
       attach_function :mt_bearbeite_vorgang, :EricMtBearbeiteVorgang, [:pointer, :string, :string,
-          Types::BearbeitungFlag, :pointer, :pointer, :pointer, :pointer, :pointer], :int
+          :uint32, :pointer, :pointer, :pointer, :pointer, :pointer], :int
 
       # ERICAPI_IMPORT int STDCALL EricMtCheckXML(
       #     EricInstanzHandle instanz, const char* xml, const char* datenartVersion,

--- a/lib/liberic/sdk/api.rb
+++ b/lib/liberic/sdk/api.rb
@@ -275,7 +275,7 @@ module Liberic
       #     EricRueckgabepufferHandle rueckgabeXmlPuffer,
       #     EricRueckgabepufferHandle serverantwortXmlPuffer);
       attach_function :mt_bearbeite_vorgang, :EricMtBearbeiteVorgang, [:pointer, :string, :string,
-          :uint32, :pointer, :pointer, :pointer, :pointer], :int
+          Types::BearbeitungFlag, :pointer, :pointer, :pointer, :pointer], :int
 
       # ERICAPI_IMPORT int STDCALL EricMtCheckXML(
       #     EricInstanzHandle instanz, const char* xml, const char* datenartVersion,

--- a/lib/liberic/sdk/api.rb
+++ b/lib/liberic/sdk/api.rb
@@ -272,11 +272,10 @@ module Liberic
       #     EricInstanzHandle instanz, const char* datenpuffer, const char* datenartVersion,
       #     uint32_t bearbeitungsFlags, const eric_druck_parameter_t* druckParameter,
       #     const eric_verschluesselungs_parameter_t* cryptoParameter,
-      #     EricTransferHandle* transferHandle,
       #     EricRueckgabepufferHandle rueckgabeXmlPuffer,
       #     EricRueckgabepufferHandle serverantwortXmlPuffer);
       attach_function :mt_bearbeite_vorgang, :EricMtBearbeiteVorgang, [:pointer, :string, :string,
-          :uint32, :pointer, :pointer, :pointer, :pointer, :pointer], :int
+          :uint32, :pointer, :pointer, :pointer, :pointer], :int
 
       # ERICAPI_IMPORT int STDCALL EricMtCheckXML(
       #     EricInstanzHandle instanz, const char* xml, const char* datenartVersion,
@@ -300,6 +299,25 @@ module Liberic
       #     EricInstanzHandle instanz, EricZertifikatHandle hToken,
       #     const byteChar* pin, EricRueckgabepufferHandle rueckgabeXmlPuffer);
       attach_function :mt_hole_zertifikat_eigenschaften, :EricMtHoleZertifikatEigenschaften, [:pointer, :uint, :string, :pointer], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtEinstellungLesen(
+      #     EricInstanzHandle instanz, const char *name,
+      #     EricRueckgabepufferHandle rueckgabePuffer);
+      attach_function :mt_einstellung_lesen, :EricMtEinstellungLesen, [:pointer, :string, :pointer], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtEinstellungSetzen(
+      #     EricInstanzHandle instanz, const char *name, const byteChar *wert);
+      attach_function :mt_einstellung_setzen, :EricMtEinstellungSetzen, [:pointer, :string, :string], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtRegistriereLogCallback(
+      #     EricInstanzHandle instanz, EricLogCallback funktion,
+      #     uint32_t schreibeEricLogDatei, void *benutzerdaten);
+      attach_function :mt_registriere_log_callback, :EricMtRegistriereLogCallback, [:pointer, :log_callback, :uint, :pointer], :int
+
+      # ERICAPI_IMPORT int STDCALL EricMtHoleFehlerText(
+      #     EricInstanzHandle instanz, int fehlerkode,
+      #     EricRueckgabepufferHandle rueckgabePuffer);
+      attach_function :mt_hole_fehler_text, :EricMtHoleFehlerText, [:pointer, :int, :pointer], :int
 
       # ERICAPI_IMPORT int STDCALL EricSystemCheck(
       #     void);

--- a/lib/liberic/sdk/configuration.rb
+++ b/lib/liberic/sdk/configuration.rb
@@ -1,7 +1,7 @@
 module Liberic
   module SDK
     module Configuration
-      LIBERICAPI_VERSION = %w(44.2.4.0)
+      LIBERICAPI_VERSION = %w(44.2.4.0 44.2.4.1)
       ENCODING = 'iso-8859-15'
     end
   end

--- a/lib/liberic/sdk/configuration.rb
+++ b/lib/liberic/sdk/configuration.rb
@@ -1,7 +1,7 @@
 module Liberic
   module SDK
     module Configuration
-      LIBERICAPI_VERSION = %w(42.2.2.0)
+      LIBERICAPI_VERSION = %w(44.2.4.0)
       ENCODING = 'iso-8859-15'
     end
   end

--- a/lib/liberic/sdk/configuration.rb
+++ b/lib/liberic/sdk/configuration.rb
@@ -1,7 +1,7 @@
 module Liberic
   module SDK
     module Configuration
-      LIBERICAPI_VERSION = %w(44.2.4.0 44.2.4.1)
+      LIBERICAPI_VERSION = %w(44.2.4.1)
       ENCODING = 'iso-8859-15'
     end
   end

--- a/lib/liberic/sdk/types.rb
+++ b/lib/liberic/sdk/types.rb
@@ -4,7 +4,7 @@ module Liberic
       extend FFI::Library
 
       class DruckParameter < FFI::Struct
-        layout :version,     :uint,
+        layout :version,     :uint, # Set version to 4
                :vorschau,    :uint,
                :duplexDruck, :uint,
                :pdfName,     :pointer,

--- a/lib/liberic/sdk/types.rb
+++ b/lib/liberic/sdk/types.rb
@@ -4,12 +4,13 @@ module Liberic
       extend FFI::Library
 
       class DruckParameter < FFI::Struct
-        layout :version,     :uint, # Set version to 4
+        layout :version,     :uint,
                :vorschau,    :uint,
                :duplexDruck, :uint,
                :pdfName,     :pointer,
                :fussText,    :pointer,
-               :ersteSeite,  :uint
+               :pdfCallback, :pointer,
+               :pdfCallbackBenutzerdaten, :pointer
       end
 
       class VerschluesselungsParameter < FFI::Struct

--- a/lib/liberic/version.rb
+++ b/lib/liberic/version.rb
@@ -1,3 +1,3 @@
 module Liberic
-  VERSION = '1.4.1'
+  VERSION = '1.44.0'
 end


### PR DESCRIPTION
## Why do we need this?

ERiC 44.x removes the single-threaded (ST) SDK API that this gem relied on, so the gem no longer works against current ERiC libraries. Upgrading to ERiC 44 is required to stay on ELSTER-supported releases and to unblock consuming apps that need the latest ERiC.

## What did you change (in details) to resolve the issue?

- Migrated every ERiC SDK call from the deprecated single-threaded API to the multithreading (MT) API
- Introduced a lazily-created shared ERiC instance that all SDK calls now flow through
- Updated the supported ERiC version to the 44.2.4.x line
- Adjusted the print-parameter data layout to match the ERiC 44 structure and dropped a parameter ERiC 44 no longer accepts
- Bumped the gem version

## References

- _Add Linear/GitHub ticket link_

## How to QA this PR?

- With ERiC 44.2.4.x libraries installed and `ERIC_HOME_40` pointing at them, run a full validate → submit → print flow and confirm each returns the expected result/server buffers
- Confirm certificate handling (loading a portal certificate, reading its properties, encryption params) works end to end
- Confirm that running against a non-matching ERiC version emits a warning rather than raising

## Screenshots

N/A

## Reviewing

Native ERiC libraries and `ERIC_HOME_40` are required to exercise this locally.
